### PR TITLE
Cap note height and add character limit (#17)

### DIFF
--- a/src/RetrospectiveModel.ts
+++ b/src/RetrospectiveModel.ts
@@ -1,14 +1,14 @@
-import { IFluidContainer, ISharedMap, SharedMap } from "fluid-framework";
-import { AzureMember } from "@fluidframework/azure-client";
-import { NoteData, Position } from "./Types";
+import { AzureMember } from '@fluidframework/azure-client';
+import { IFluidContainer, ISharedMap, SharedMap } from 'fluid-framework';
+import { NoteData, Position } from './Types';
 
-const c_NoteIdPrefix = "noteId_";
-const c_PositionPrefix = "position_";
-const c_AuthorPrefix = "author_";
-const c_LastEditedPrefix = "lastEdited_";
-const c_votePrefix = "vote_";
-const c_TextPrefix = "text_";
-const c_ColorPrefix = "color_";
+const c_NoteIdPrefix = 'noteId_';
+const c_PositionPrefix = 'position_';
+const c_AuthorPrefix = 'author_';
+const c_LastEditedPrefix = 'lastEdited_';
+const c_votePrefix = 'vote_';
+const c_TextPrefix = 'text_';
+const c_ColorPrefix = 'color_';
 
 export type RetrospectiveModel = Readonly<{
   CreateNote(noteId: string, myAuthor: AzureMember): NoteData;
@@ -47,12 +47,15 @@ export function createRetrospectiveModel(fluid: IFluidContainer): RetrospectiveM
 
   // when setting the note text in the sharedMap with the new value, also update the last edited author name and time.
   const SetNoteText = (noteId: string, noteText: string, lastEditedId: string, lastEditedName: string, lastEditedTime: number) => {
-    // update the note's text in sharedMap
-    sharedMap.set(c_TextPrefix + noteId, noteText);
-    // update the note's last edited author name and timestamp
-    // WARNING: sharedMap does not preserve object references in the DDS map the same way it would be in a conventional map data structure.
-    // Hence, instead of storing the entire AzureMember object, we are only storing the necessary primitive data types metadata.
-    sharedMap.set(c_LastEditedPrefix + noteId, { userId: lastEditedId, userName: lastEditedName, time: lastEditedTime });
+    const characterLimit = 300;
+    if (noteText.length < characterLimit) {
+      // update the note's text in sharedMap
+      sharedMap.set(c_TextPrefix + noteId, noteText);
+      // update the note's last edited author name and timestamp
+      // WARNING: sharedMap does not preserve object references in the DDS map the same way it would be in a conventional map data structure
+      // Hence, instead of storing the entire AzureMember object, we are only storing the necessary primitive data types metadata.
+      sharedMap.set(c_LastEditedPrefix + noteId, {userId: lastEditedId, userName: lastEditedName, time: lastEditedTime});
+    }
   };
 
   const SetNoteColor = (noteId: string, noteColor: string) => {

--- a/src/view/Column.tsx
+++ b/src/view/Column.tsx
@@ -1,4 +1,4 @@
-import { Text, Theme } from "@fluentui/react";
+import { Text, Theme } from '@fluentui/react';
 import { NoteData, Position } from '../Types';
 import { Note } from './Note';
 import React from 'react';
@@ -54,8 +54,15 @@ export function Column(props: ColumnProps) {
               props.model.MoveNote(note.id, position);
             };
 
-            const setText = (text: string) => {
-              props.model.SetNoteText(note.id, text, props.author.userId, props.author.userName, Date.now());
+            const setText = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+              const maxNoteBodyHeight = 182;
+              const currentText = note.text;
+              const newText = event.currentTarget.value;
+              // Prevent note from expanding vertically (is the text at the max height yet?), but allow deleting text.
+              if (event.currentTarget.offsetHeight < maxNoteBodyHeight || (currentText && (newText.length < currentText.length))) {
+                console.log(event.currentTarget.offsetHeight);
+                props.model.SetNoteText(note.id, event.currentTarget.value, props.author.userId, props.author.userName, Date.now());
+              }
             };
 
             const onLike = () => {

--- a/src/view/Note.tsx
+++ b/src/view/Note.tsx
@@ -1,18 +1,13 @@
-import {
-  mergeStyles, Theme,
-} from "@fluentui/react";
-import { AzureMember } from "@fluidframework/azure-client";
-import React, { useState } from "react";
-import { useDrag } from "react-dnd";
-import { DefaultColor } from "./Color";
-import {
-  getRootStyleForColor
-} from "./Note.style";
-import { NoteData, Position } from "../Types";
-import { NoteHeader } from "./NoteHeader";
-import { NoteBody } from "./NoteBody";
-import { NoteFooter } from "./NoteFooter";
-import { DefaultTheme } from './Themes';
+import { mergeStyles, Theme, } from '@fluentui/react';
+import { AzureMember } from '@fluidframework/azure-client';
+import React from 'react';
+import { useDrag } from 'react-dnd';
+import { DefaultColor } from './Color';
+import { getRootStyleForColor } from './Note.style';
+import { NoteData, Position } from '../Types';
+import { NoteHeader } from './NoteHeader';
+import { NoteBody } from './NoteBody';
+import { NoteFooter } from './NoteFooter';
 
 export type NoteProps = Readonly<{
   id: string;
@@ -23,7 +18,7 @@ export type NoteProps = Readonly<{
   getLikedUsers: () => AzureMember[];
   onDelete: () => void;
   onColorChange: (color: string) => void;
-  setText: (text: string) => void;
+  setText: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }> &
   Pick<
     NoteData,

--- a/src/view/NoteBody.tsx
+++ b/src/view/NoteBody.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { TextField, Theme } from "@fluentui/react";
-import { NoteData } from "../Types";
-import { ColorOptions, DefaultColor } from "./Color";
+import React from 'react';
+import { TextField, Theme } from '@fluentui/react';
+import { NoteData } from '../Types';
+import { ColorOptions, DefaultColor } from './Color';
 
 export type NoteBodyProps = Readonly<{
   theme: Theme
-  setText(text: string): void;
+  setText(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void;
 }> &
   Pick<NoteData, "text" | "color">;
 
@@ -20,7 +20,7 @@ export function NoteBody(props: NoteBodyProps) {
         multiline
         resizable={false}
         autoAdjustHeight
-        onChange={(event) => setText(event.currentTarget.value)}
+        onChange={(event) => setText(event)}
         value={text}
         placeholder={"Enter Text Here"}
       />


### PR DESCRIPTION
- A note's height now cannot be changed by typing.
- Added a character limit of 300 to note text.

It would still be possible to expand the note if pasting
a value with less than 300 characters.
Too much of an edge-case with minimal impact though.

Closes #17.