### PR TITLE
Improve text colors in dark theme

### DIFF
--- a/src/view/Note.style.ts
+++ b/src/view/Note.style.ts
@@ -34,12 +34,14 @@ export const colorButtonStyle: IButtonStyles = {
   iconExpanded: { fontSize: "18px" }
 };
 
-export const likesButtonStyle: IButtonStyles = {
-  root: { backgroundColor: "transparent" },
-  rootHovered: { backgroundColor: "transparent", fontSize: "18px" },
-  rootPressed: { backgroundColor: "transparent" },
-  iconHovered: { fontSize: "18px" }
-};
+export function getLikesButtonStyle(theme: Theme) {
+  return {
+    root: { backgroundColor: "transparent", color: theme.palette.themeDark },
+    rootHovered: { backgroundColor: "transparent", fontSize: "18px", color: theme.palette.themeDark },
+    rootPressed: { backgroundColor: "transparent", color: theme.palette.themeDark },
+    iconHovered: { fontSize: "18px" }
+  };
+}
 
 export function getRootStyleForColor(color: ColorId, theme: Theme): IStyle {
   return {

--- a/src/view/NoteHeader.tsx
+++ b/src/view/NoteHeader.tsx
@@ -11,7 +11,7 @@ import {
   getHeaderStyleForColor,
   deleteButtonStyle,
   colorButtonStyle,
-  likesButtonStyle,
+  getLikesButtonStyle,
 } from "./Note.style";
 import { NoteProps } from "./Note"
 
@@ -53,7 +53,7 @@ const HeaderComponent = (props: NoteProps) => {
       iconProps: {
         iconName: props.didILikeThisCalculated ? "LikeSolid" : "Like",
       },
-      buttonStyles: likesButtonStyle,
+      buttonStyles: getLikesButtonStyle(props.theme),
       commandBarButtonAs: (props) => {
         return (
           <CommandBarButton {...(props as any)} />

--- a/src/view/Themes.ts
+++ b/src/view/Themes.ts
@@ -55,6 +55,10 @@ export const darkTheme = createTheme({
     black: "#f8f8f8",
     white: "#000000",
   },
+  semanticColors: {
+    inputPlaceholderText: "#a2a1a0",
+    inputText: "#30302f"
+  }
 });
 
 export function themeNameToTheme(themeName: ThemeName) {


### PR DESCRIPTION
Fixes #18. I'm super unfamiliar with `fluentui` so let me know if it's not the right approach!

I couldn't figure out what changes the caret color for the theme picker :cry:  

Examples light/dark themes:

![image](https://user-images.githubusercontent.com/6775216/153094445-12702dc8-bcff-4273-a544-824660d1906f.png)

![image](https://user-images.githubusercontent.com/6775216/153094479-43dbc305-2c11-4b3c-8529-f17094ae8672.png)
